### PR TITLE
Local script tag source should start with file://

### DIFF
--- a/lib/docma.template.js
+++ b/lib/docma.template.js
@@ -517,7 +517,7 @@ module.exports = (function () {
                         var docmaCss = domUtil.getStyleElem('css/docma.css') + domUtil.N_TAB;
                         _insertBeforeFirst(head, 'link[rel=stylesheet]', docmaCss);
 
-                    }, [$this.paths.JQUERY]);
+                    }, [`file://${$this.paths.JQUERY}`);
                     // }, ['https://code.jquery.com/jquery.min.js']);
             })
             .then(function (parser) {


### PR DESCRIPTION
For some reason, it worked in Unix, but did not under Windows where the script silentely failed to be loaded and later produced the error `$ is not a function`.

This makes sure the script is loaded in both Windows & Unix and fixes #16