### PR TITLE
Handle multiple parameter types (such as Map<String, String>)

### DIFF
--- a/lib/web/DocmaWeb.Utils.js
+++ b/lib/web/DocmaWeb.Utils.js
@@ -961,16 +961,26 @@ Utils._parseAnchorLinks = function (docsOrApis, strType, options) {
     var m = strType.match(reTypeParts);
     if (!m || !m[1]) return '';
     // maybe we have end brackets e.g. Boolean[] or Promise<Boolean>[]
-    var endBrackets = m[3] || '';
-    var sTypes = '';
-    // check for sub-types e.g. Promise<Boolean|String>
-    if (m[2]) {
-        sTypes = m[2].split('|');
-        sTypes = sTypes.map(function (t) {
-            return _link(docsOrApis, t, options);
-        }).join('<span class="code-delim">|</span>');
-        if (sTypes) sTypes = '&lt;' + sTypes + '&gt;';
+    var endBrackets = m[4] || '';
+    var sTypes = m[2] || m[3];
+    // check for multiple types e.g. Map<String, String>
+    if (sTypes) {
+        sTypes = (m[2] || m[3])
+            .split(',')
+            .map(function (outerT) {
+                // check for sub-types e.g. Promise<Boolean|String>
+                return outerT
+                    .trim()
+                    .split('|')
+                    .map(function (t) {
+                        return _link(docsOrApis, t, options);
+                    })
+                    .join('<span class="code-delim">|</span>');
+            })
+            .join('<span class="code-delim">, </span>');
     }
+    if (sTypes) sTypes = '&lt;' + sTypes + '&gt;';
+    // check for sub-types e.g. Promise<Boolean|String>
     return _link(docsOrApis, m[1], options) + sTypes + endBrackets;
 };
 

--- a/lib/web/DocmaWeb.Utils.js
+++ b/lib/web/DocmaWeb.Utils.js
@@ -962,7 +962,7 @@ Utils._parseAnchorLinks = function (docsOrApis, strType, options) {
     if (!m || !m[1]) return '';
     // maybe we have end brackets e.g. Boolean[] or Promise<Boolean>[]
     var endBrackets = m[4] || '';
-    var sTypes = m[2] || m[3];
+    var sTypes = m[2] || m[3] || '';
     // check for multiple types e.g. Map<String, String>
     if (sTypes) {
         sTypes = (m[2] || m[3])

--- a/lib/web/DocmaWeb.Utils.js
+++ b/lib/web/DocmaWeb.Utils.js
@@ -919,10 +919,10 @@ Utils.getSymbolLink = function (docsOrApis, symbolOrName) {
 };
 
 var reEndBrackets = /\[\]$/;
-// regexp for inspecting type parts such as `Promise<Boolean|String>[]` or
-// simply `Boolean`. this also removes/ignores dots from types such as
-// Array.<String>
-var reTypeParts = /^([^<]+?)(?:\.)?(?:<([^>]+)>)?(\[\])?$/;
+// regexp for inspecting type parts such as `Map<String, Object>`,
+// `Promise<Boolean|String>[]` or simply `Boolean`. this also
+// removes/ignores dots from types such as Array.<String>
+var reTypeParts = /^([^<]+?)(?:\.)?(?:<\(([^>)]+)\)>)?(?:<([^>]+)>)?(\[\])?$/;
 
 function _link(docsOrApis, type, options) {
     var endBrackets = reEndBrackets.test(type) ? '[]' : '';


### PR DESCRIPTION
For some types it can make sense to specify multiple parameter types. A prime example of this is `Map`, where it can be useful to specify the type of the keys and the type of the values separately. This change allows doing so, in the following form:

`Map<String, Object>`